### PR TITLE
Fix for systems using non-nested currency objects

### DIFF
--- a/scripts/loot/loot-creator.js
+++ b/scripts/loot/loot-creator.js
@@ -36,8 +36,13 @@ export class LootCreator {
         const lootCurrency = this.currencyData;
         for (var key in lootCurrency) {
             if (currencyData.hasOwnProperty(key)) {
-                const amount = Number(currencyData[key].value || 0) + Number(lootCurrency[key]);
-                currencyData[key] = {"value": amount.toString()};
+                if (typeof(currencyData[key]) == 'object') {
+                    const amount = Number(currencyData[key].value || 0) + Number(lootCurrency[key]);
+                    currencyData[key] = {"value": amount.toString()};
+                } else {
+                    const amount = Number(currencyData[key] || 0) + Number(lootCurrency[key]);
+                    currencyData[key] = amount.toString();
+                }
             }
         }
         await this.actor.update({"data.currency": currencyData});


### PR DESCRIPTION
While most systems seem to use the nested currency format:
```{"pp": { "value": 8}, "gp": {"value": 5}, "sp": {"value": 2},  "cp": {"value": 5}}```
there are some, like PF1E, that use a non-nested variant:
```{"pp": 8, "gp": 5, "sp": 2, "cp": 5}```

This fix expands upon the addCurrenciesToActor() function so that input and output data format will match. This allows better-rolltables' currency generation functionality to be used in the PF1E system, and perhaps others.