### PR TITLE
Fixes: Spell scroll, table from Compendium

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -1,0 +1,22 @@
+{
+    "BRT.TypeLabel": "`Better Table` Typ",
+    "BRT.TypeDefault": "Standard Tabelle",
+    "BRT.BetterTable": "`Better Table` Tabelle",
+    "BRT.TypeLoot": "Beute Tabelle (loot)",
+    "BRT.StoryLoot": "Story Tabelle",
+    "BRT.CurrencyLoot": "Währungsbeute",
+    "BRT.Currency": "Währung:",
+    "BRT.CurrencyLootPlaceholder": "Komma separierte Formel(n) z.B.: 1d4[gp], (1d4+1)*10[sp]",
+    "BRT.LootActorName": "Beute zu Akteur hinzufügen",
+    "BRT.LootActorNamePlaceholder": "Wenn leer, wird immer ein neuer Akteur erzeugt",
+    "BRT.GenerateLoot.Button": " Beute generieren",
+    "BRT.Settings.LootSheet.Title": "Bogen der für generierte Beute genutzt wird",
+    "BRT.Settings.LootSheet.Description": "Du kannst einen alternativen Bogen für die Beuteerzeugung wählen.",
+    "BRT.Settings.SpellCompendium.Title": "Kompendium für zufällige Zauberrollen",
+    "BRT.Settings.SpellCompendium.Description": "Du kannst ein Kompendium wählen das für Zauber genutzt wenn zufällige Zauberschriftrollen erzeugt werden.",
+    "BRT.LootRollAmount": "Anzahl an Würfen",
+    "BRT.LootRollAmountPlaceholder" : "Mehrfach auf die Tabelle würfeln.",
+    "BRT.DrawResultPlural": "Zieht {amount} Ergebnisse aus {name}",
+    "BRT.DrawResultSingular": "Zieht {amount} Ergebnis aus {name}",
+    "BRT.DrawResultZero": "Würfle auf {name}"
+}

--- a/module.json
+++ b/module.json
@@ -35,6 +35,11 @@
   "compatibleCoreVersion": "0.8.8",
   "languages": [
     {
+      "lang": "de",
+      "name": "Deutsch (German)",
+      "path": "lang/de.json"
+    },
+    {
       "lang": "en",
       "name": "English",
       "path": "lang/en.json"

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "better-rolltables",
   "title": "Better Roll Tables",
   "description": "Adding functionality to roll tables, especially to roll treasure and magic items",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "author": "Ultrakorne#6240",
   "esmodules": [
     "./scripts/brt-main.js"
@@ -57,5 +57,5 @@
   ],
   "url": "https://github.com/ultrakorne/better-rolltables",
   "manifest": "https://raw.githubusercontent.com/ultrakorne/better-rolltables/master/module.json",
-  "download": "https://github.com/ultrakorne/better-rolltables/releases/download/v1.6.11/better-rolltables.zip"
+  "download": "https://github.com/ultrakorne/better-rolltables/releases/download/v1.6.12/better-rolltables.zip"
 }

--- a/scripts/brt-main.js
+++ b/scripts/brt-main.js
@@ -28,6 +28,7 @@ Hooks.on("ready", () => {
 });
 
 Hooks.on("renderRollTableConfig", BetterRT.enhanceRollTableView);
+Hooks.on('getCompendiumDirectoryEntryContext', BetterTables.enhanceCompendiumContextMenu);
 
 function registerSettings() {
   let defaultLootSheet = "dnd5e.LootSheet5eNPC";

--- a/scripts/core/brt-table-results.js
+++ b/scripts/core/brt-table-results.js
@@ -38,6 +38,7 @@ export class BetterResults {
             for (let t of textResults) {
                 //if the text is a currency, we process that first
                 t = this._processTextAsCurrency(t);
+                t = this._rollInlineDice(t);
 
                 const regex = /(\s*[^\[@]*)@*(\w+)*\[([\w.,*+-\/\(\)]+)\]/g;
                 let textString = t,
@@ -133,6 +134,21 @@ export class BetterResults {
         for (let key in currencyData) {
             this.currencyData[key] = (this.currencyData[key] || 0) + currencyData[key];
         }
+    }
+
+    /**
+     * 
+     * @param {string} tableText 
+     * @returns 
+     */
+    _rollInlineDice(tableText) {
+        let regex = /\[{2}(\w*[^\]])\]{2}/g,
+            matches;
+        while ((matches = regex.exec(tableText)) != null) {
+            tableText = tableText.replace(matches[0], BRTHelper.tryRoll(matches[1]));
+        }
+
+        return tableText;
     }
 
     /**

--- a/scripts/loot/loot-chat-card.js
+++ b/scripts/loot/loot-chat-card.js
@@ -6,6 +6,7 @@ import { BRTCONFIG } from '../core/config.js';
  * create a chat card based on the content of the object LootData
  */
 export class LootChatCard {
+
     /**
      * @param {object} betterResults 
      * @param {object} currencyData
@@ -24,34 +25,35 @@ export class LootChatCard {
             this.numberOfDraws++;
             /** we pass though the data, since we might have some data manipulation that changes an existing item, in that case even if it was initially 
              * existing or in a compendium we have to create a new one */
-            const data = await lootCreator.buildItemData(item);
+            const itemData = await lootCreator.buildItemData(item);
             if (item.collection) {                
                 const itemEntity = await getItemFromCompendium(item);
 
-                if (itemEntity) {
-                    this.addToItemData(itemEntity, data);
+                if (itemEntity && (itemEntity.name == itemData.name)) {
+                    this.addToItemData(itemEntity, itemData);
                     continue;
                 }                         
             }
 
-            const itemEntity = game.items.getName(data.name);
+            const itemEntity = game.items.getName(itemData.name);
             if (itemEntity) {
-                this.addToItemData(itemEntity, data);
+                this.addToItemData(itemEntity, itemData);
                 continue;
             }
 
             const itemFolder = await this.getBRTFolder();
-            data.folder = itemFolder.id;
+            itemData.folder = itemFolder.id;
 
-            setProperty(data, "permission.default", CONST.ENTITY_PERMISSIONS.OBSERVER);
-            const newItem = await Item.create(data);
-            this.addToItemData(newItem, data);
+            setProperty(itemData, "permission.default", CONST.ENTITY_PERMISSIONS.OBSERVER);
+            const newItem = await Item.create(itemData);
+            this.addToItemData(newItem, itemData);
         }
     }
 
     addToItemData(itemEntity, data) {
         const existingItem = this.itemsData.find(i => i.item.id === itemEntity.id),
             quantity = getProperty(data, BRTCONFIG.QUANTITY_PROPERTY_PATH) || 1;
+
         if (existingItem) {
             existingItem.quantity = +existingItem.quantity + +quantity;
         } else {

--- a/templates/loot-chat-card.hbs
+++ b/templates/loot-chat-card.hbs
@@ -15,9 +15,9 @@
             <div class="result-text" style="font-size: {{itemData.fontSize}}%;">
                 <a class="entity-link" draggable="true" data-entity="Item" 
                 {{#if itemData.item.compendium}}
-                    data-pack="{{itemData.item.compendium.collection}}" data-lookup="{{itemData.item.id}}" 
+                    data-pack="{{itemData.item.compendium.collection}}" data-lookup="{{itemData.item._id}}" 
                     {{else}}
-                    data-id="{{itemData.item.id}}" 
+                    data-id="{{itemData.item._id}}" 
                     {{/if}}>
                     <i class="fas fa-suitcase"></i> {{itemData.item.name}}
                 </a>

--- a/templates/loot-chat-card.hbs
+++ b/templates/loot-chat-card.hbs
@@ -21,7 +21,7 @@
                     {{/if}}>
                     <i class="fas fa-suitcase"></i> {{itemData.item.name}}
                 </a>
-                <strong>&nbsp;x{{itemData.quantity}}</strong>
+                <strong>&nbsp; &#xD7; {{itemData.quantity}}</strong>
             </div>
         </li>
         {{/each}}


### PR DESCRIPTION
Fixed generation of spellscrolls.

The way the indexes are generated in 0.8.x is different from before.
Had to change calls from array checks to mpa checks.

* Also update spell name in the spellscroll again
* Add link and description of spell to the spell scrolls
* Updated the method to generate tables from a compendium
* Added an entry to the contextmenu of a compendium to start generation
* Fixes inline rolls like `Lorem ipsum got [[3d6]] of dolor sit amet` 
* Adds German translation

- Fixes #84
- Fixes #77 
