### PR TITLE
Story text selectable & Hotfix "entity in Compendium undefined"

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "better-rolltables",
   "title": "Better Roll Tables",
   "description": "Adding functionality to roll tables, especially to roll treasure and magic items",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "author": "Ultrakorne#6240",
   "esmodules": [
     "./scripts/brt-main.js"
@@ -62,5 +62,5 @@
   ],
   "url": "https://github.com/ultrakorne/better-rolltables",
   "manifest": "https://raw.githubusercontent.com/ultrakorne/better-rolltables/master/module.json",
-  "download": "https://github.com/ultrakorne/better-rolltables/releases/download/v1.6.12/better-rolltables.zip"
+  "download": "https://github.com/ultrakorne/better-rolltables/releases/download/v1.6.13/better-rolltables.zip"
 }

--- a/scripts/core/brt-builder.js
+++ b/scripts/core/brt-builder.js
@@ -78,7 +78,7 @@ export class BRTBuilder {
                     innerTable = game.tables.get(entry.data.resultId);
                 } else if (entry.data.type === CONST.TABLE_RESULT_TYPES.COMPENDIUM) {
                     const entityInCompendium = await Utils.findInCompendiumByName(entry.data.collection, entry.data.text);
-                    if (entityInCompendium.documentName === "RollTable") {
+                    if ((entityInCompendium != undefined) && entityInCompendium.documentName === "RollTable") {
                         innerTable = entityInCompendium;
                     }
                 }

--- a/scripts/story/story-chat-card.js
+++ b/scripts/story/story-chat-card.js
@@ -13,6 +13,9 @@ export class StoryChatCard {
     createChatCard(story, options = {}) {
         if (!story) return;
 
+        //quickfix for textselection of stories
+        story = '<div class="story-text-selectable">' + story + "</div>";
+        
         let chatData = {
             flavor: this._tableEntity.data.name,
             sound: "sounds/dice.wav",

--- a/styles/brt.css
+++ b/styles/brt.css
@@ -31,3 +31,8 @@
   width: 84%;
   margin-left: 3px;
 }
+
+.story-text-selectable * {
+  user-select: text;
+  -moz-user-select: text;
+}


### PR DESCRIPTION
Make story text selectable 

Also contains a hotfix that checks if `entityInCompendium` is undefined before checking it's property.

Fixes #71 