### PR TITLE
Roll from everywhere!

### DIFF
--- a/scripts/better-tables.js
+++ b/scripts/better-tables.js
@@ -4,7 +4,9 @@ import { StoryBuilder } from './story/story-builder.js';
 import { StoryChatCard } from './story/story-chat-card.js';
 import { BRTBuilder } from './core/brt-builder.js';
 import { BetterResults } from './core/brt-table-results.js';
+import { getRandomItemFromCompendium } from "./core/utils.js";
 import { BRTCONFIG } from "./core/config.js";
+
 
 export class BetterTables {
     __constructor() {
@@ -175,6 +177,14 @@ export class BetterTables {
                 BetterTables.menuCallBackCreateTable(li.data('pack'));
             }
         });
+
+        options.push({
+            "name": "Roll on compendium",
+            "icon": '<i class="fas fa-dice-d20"></i>',
+            "callback": li => {
+                BetterTables.menuCallBackRollCompendium(li.data('pack'));
+            }
+        });
     }
 
     /**
@@ -207,5 +217,30 @@ export class BetterTables {
     static async menuCallBackRollTable(rolltable_id){
         const rolltable = game.tables.get(rolltable_id);
         await game.betterTables.betterTableRoll(rolltable);
+    }
+
+    /**
+     *
+     * @param {String} compendium ID of the compendium to roll
+     */
+    static async menuCallBackRollCompendium(compendium) {
+        // Get random item from compendium
+        const item = await getRandomItemFromCompendium(compendium);
+
+        // prepare card data
+        const fontSize = Math.max(60, 100 - Math.max(0, item.name.length - 27) * 2);
+        const chatCardData = {
+            itemsData: [
+                { item: item, quantity: 1, fontSize: fontSize }
+            ]
+        };
+        const cardHtml = await renderTemplate("modules/better-rolltables/templates/loot-chat-card.hbs", chatCardData);
+        const chatData = {
+            flavor: `Rolled from compendium ${item.pack}`,
+            sound: "sounds/dice.wav",
+            user: game.user.data._id,
+            content: cardHtml
+        };
+        ChatMessage.create(chatData);
     }
 }

--- a/scripts/better-tables.js
+++ b/scripts/better-tables.js
@@ -179,9 +179,33 @@ export class BetterTables {
 
     /**
      *
-     * @param {String} compendium
+     * @param {String} compendium_id
      */
     static async menuCallBackCreateTable(compendium_id){
         await game.betterTables.createTableFromCompendium('BRT | '+ compendium_id,compendium_id);
+    }
+
+    /**
+     * Add a roll option in context menu of rolltables
+     * @param {html} html
+     * @param {Array} options
+     */
+    static async enhanceRolltableContextMenu(html, options) {
+        options.push({
+            "name": "Roll table",
+            "icon": '<i class="fas fa-dice-d20"></i>',
+            "callback": li => {
+                BetterTables.menuCallBackRollTable(li.data("entityId"));
+            }
+        });
+    }
+
+    /**
+     *
+     * @param {String} rolltable_id ID of the rolltable to roll
+     */
+    static async menuCallBackRollTable(rolltable_id){
+        const rolltable = game.tables.get(rolltable_id);
+        await game.betterTables.betterTableRoll(rolltable);
     }
 }

--- a/scripts/brt-main.js
+++ b/scripts/brt-main.js
@@ -38,6 +38,7 @@ Hooks.on("updateCompendium", async function (pack, documents, option, userId) {
 
 Hooks.on("renderRollTableConfig", BetterRT.enhanceRollTableView);
 Hooks.on('getCompendiumDirectoryEntryContext', BetterTables.enhanceCompendiumContextMenu);
+Hooks.on('getRollTableDirectoryEntryContext', BetterTables.enhanceRolltableContextMenu);
 
 function registerSettings() {
   let defaultLootSheet = "dnd5e.LootSheet5eNPC";

--- a/scripts/core/utils.js
+++ b/scripts/core/utils.js
@@ -46,3 +46,21 @@ export function separateIdComendiumName(stringWithComendium) {
  export async function getItemFromCompendium(item) {
      return findInCompendiumByName(item.collection, item.text);
 }
+
+/**
+ *
+ * @param {object} compendium reference to compendium to roll
+ * @returns {object} item from compendium
+ */
+export async function getRandomItemFromCompendium(compendium) {
+    const pack = game.packs.get(compendium);
+    if (!pack) return;
+    const size = pack.index.size;
+    if (size === 0) {
+        ui.notifications.warn(`Compendium ${pack.title} is empty.`);
+        return;
+    }
+    const randonIndex = Math.floor(Math.random() * size);
+    const randomItem = pack.index.contents[randonIndex];
+    return pack.getDocument(randomItem._id);
+}


### PR DESCRIPTION
This is a little QoL PR adding new ways to roll tables nor compendiums.

# Roll table from context menu
A "roll table" action has been add to rolltables context menu to allow rolling table without opening it. Always useful for big tables.
![roll-table](https://user-images.githubusercontent.com/1334405/125739835-0fcc20f8-a5af-4ba4-8ff7-896cb98e6949.PNG)

# Roll compendium
A "Roll compendium" has been added on compendiums context menu to allow rolling on compendium without creating a specific rolltable. Useful for one-time roll and avoid garbage in campaign.
![roll-compendium](https://user-images.githubusercontent.com/1334405/125739977-05504f6f-3861-4f5c-9ab0-c62d4f19bb7f.PNG)