### PR TITLE
New QoL features

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -33,5 +33,7 @@
     "BRT.Settings.RerollWarning.Title": "Reroll?",
     "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?",
     "BRT.Settings.StickRolltableHeader.Title": "Stick rolltable header to top?",
-    "BRT.Settings.StickRolltableHeader.Description": "If enabled, roll table header will no more scroll with content."
+    "BRT.Settings.StickRolltableHeader.Description": "If enabled, roll table header will no more scroll with content.",
+    "BRT.Settings.RollTableFromJournal.Title": "Add roll button to tables in journal entries?",
+    "BRT.Settings.RollTableFromJournal.Description": "If enabled, a roll button is added to linked tables in journal entries."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -19,5 +19,7 @@
     "BRT.DrawResultPlural": "Zieht {amount} Ergebnisse aus {name}",
     "BRT.DrawResultSingular": "Zieht {amount} Ergebnis aus {name}",
     "BRT.DrawResultZero": "Würfle auf {name}",
-    "BRT.DrawReroll": "Reroll"
+    "BRT.DrawReroll": "Reroll",
+    "BRT.Settings.RerollButtons.Title":"Show reroll buttons",
+    "BRT.Settings.RerollButtons.Description":"Display a Reroll button on each result card of a roll on a rolltable (only for newly created cards)"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -18,5 +18,6 @@
     "BRT.LootRollAmountPlaceholder" : "Mehrfach auf die Tabelle würfeln.",
     "BRT.DrawResultPlural": "Zieht {amount} Ergebnisse aus {name}",
     "BRT.DrawResultSingular": "Zieht {amount} Ergebnis aus {name}",
-    "BRT.DrawResultZero": "Würfle auf {name}"
+    "BRT.DrawResultZero": "Würfle auf {name}",
+    "BRT.DrawReroll": "Reroll"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -31,5 +31,7 @@
     "BRT.Settings.AddRollInCompediumContextMenu.Title": "Roll from compendium contextmenu",
     "BRT.Settings.AddRollInCompediumContextMenu.Description": "Add an option in compendium's contextmenu to roll on this compendium without creating rolltable from it. Work on all non-empty compendiums.",
     "BRT.Settings.RerollWarning.Title": "Reroll?",
-    "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?"
+    "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?",
+    "BRT.Settings.StickRolltableHeader.Title": "Stick rolltable header to top?",
+    "BRT.Settings.StickRolltableHeader.Description": "If enabled, roll table header will no more scroll with content."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -20,6 +20,16 @@
     "BRT.DrawResultSingular": "Zieht {amount} Ergebnis aus {name}",
     "BRT.DrawResultZero": "Würfle auf {name}",
     "BRT.DrawReroll": "Reroll",
-    "BRT.Settings.RerollButtons.Title":"Show reroll buttons",
-    "BRT.Settings.RerollButtons.Description":"Display a Reroll button on each result card of a roll on a rolltable (only for newly created cards)"
+    "BRT.Settings.RerollButtons.Title": "Show Reroll buttons",
+    "BRT.Settings.RerollButtons.Description": "Display a Reroll button on each result card of a roll on a rolltable (only for newly created cards). Work only on loot chat card or if condensed roll output is enabled. Default tables are not affected.",
+    "BRT.Settings.ShowWarningBeforeReroll.Title": "Confirm reroll ?",
+    "BRT.Settings.ShowWarningBeforeReroll.Description": "Show a confirm dialog before reroll message content.",
+    "BRT.Settings.UseCondensedBetterRoll.Title": "Use condensed roll output",
+    "BRT.Settings.UseCondensedBetterRoll.Description": "If enabled, this will aggregate same output with a multiplier to save space. This option may speed up rolltable draws. Default tables are not affected.",
+    "BRT.Settings.AddRollInRolltableContextMenu.Title": "Roll from rolltable contextmenu",
+    "BRT.Settings.AddRollInRolltableContextMenu.Description": "Add an option in rolltable's contextmenu to roll table without opening it. Work on all table type.",
+    "BRT.Settings.AddRollInCompediumContextMenu.Title": "Roll from compendium contextmenu",
+    "BRT.Settings.AddRollInCompediumContextMenu.Description": "Add an option in compendium's contextmenu to roll on this compendium without creating rolltable from it. Work on all non-empty compendiums.",
+    "BRT.Settings.RerollWarning.Title": "Reroll?",
+    "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -19,5 +19,8 @@
     "BRT.DrawResultPlural": "Draws {amount} results from {name}",
     "BRT.DrawResultSingular": "Draw {amount} result from {name}",
     "BRT.DrawResultZero": "Rolling on {name}",
-    "BRT.DrawReroll": "Reroll"
+    "BRT.DrawReroll": "Reroll",
+    "BRT.Settings.RerollButtons.Title":"Show Reroll buttons",
+    "BRT.Settings.RerollButtons.Description":"Display a Reroll button on each result card of a roll on a rolltable (only for newly created cards)"
 }
+

--- a/lang/en.json
+++ b/lang/en.json
@@ -18,5 +18,6 @@
     "BRT.LootRollAmountPlaceholder" : "Roll the entire table multiple times",
     "BRT.DrawResultPlural": "Draws {amount} results from {name}",
     "BRT.DrawResultSingular": "Draw {amount} result from {name}",
-    "BRT.DrawResultZero": "Rolling on {name}"
+    "BRT.DrawResultZero": "Rolling on {name}",
+    "BRT.DrawReroll": "Reroll"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -33,6 +33,8 @@
     "BRT.Settings.RerollWarning.Title": "Reroll?",
     "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?",
     "BRT.Settings.StickRolltableHeader.Title": "Stick rolltable header to top?",
-    "BRT.Settings.StickRolltableHeader.Description": "If enabled, roll table header will no more scroll with content."
+    "BRT.Settings.StickRolltableHeader.Description": "If enabled, roll table header will no more scroll with content.",
+    "BRT.Settings.RollTableFromJournal.Title": "Add roll button to tables in journal entries?",
+    "BRT.Settings.RollTableFromJournal.Description": "If enabled, a roll button is added to linked tables in journal entries."
 
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -20,7 +20,16 @@
     "BRT.DrawResultSingular": "Draw {amount} result from {name}",
     "BRT.DrawResultZero": "Rolling on {name}",
     "BRT.DrawReroll": "Reroll",
-    "BRT.Settings.RerollButtons.Title":"Show Reroll buttons",
-    "BRT.Settings.RerollButtons.Description":"Display a Reroll button on each result card of a roll on a rolltable (only for newly created cards)"
+    "BRT.Settings.RerollButtons.Title": "Show Reroll buttons",
+    "BRT.Settings.RerollButtons.Description": "Display a Reroll button on each result card of a roll on a rolltable (only for newly created cards). Work only on loot chat card or if condensed roll output is enabled. Default tables are not affected.",
+    "BRT.Settings.ShowWarningBeforeReroll.Title": "Confirm reroll ?",
+    "BRT.Settings.ShowWarningBeforeReroll.Description": "Show a confirm dialog before reroll message content.",
+    "BRT.Settings.UseCondensedBetterRoll.Title": "Use condensed roll output",
+    "BRT.Settings.UseCondensedBetterRoll.Description": "If enabled, this will aggregate same output with a multiplier to save space. This option may speed up rolltable draws. Default tables are not affected.",
+    "BRT.Settings.AddRollInRolltableContextMenu.Title": "Roll from rolltable contextmenu",
+    "BRT.Settings.AddRollInRolltableContextMenu.Description": "Add an option in rolltable's contextmenu to roll table without opening it. Work on all table type.",
+    "BRT.Settings.AddRollInCompediumContextMenu.Title": "Roll from compendium contextmenu",
+    "BRT.Settings.AddRollInCompediumContextMenu.Description": "Add an option in compendium's contextmenu to roll on this compendium without creating rolltable from it. Work on all non-empty compendiums.",
+    "BRT.Settings.RerollWarning.Title": "Reroll?",
+    "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?"
 }
-

--- a/lang/en.json
+++ b/lang/en.json
@@ -31,5 +31,8 @@
     "BRT.Settings.AddRollInCompediumContextMenu.Title": "Roll from compendium contextmenu",
     "BRT.Settings.AddRollInCompediumContextMenu.Description": "Add an option in compendium's contextmenu to roll on this compendium without creating rolltable from it. Work on all non-empty compendiums.",
     "BRT.Settings.RerollWarning.Title": "Reroll?",
-    "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?"
+    "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?",
+    "BRT.Settings.StickRolltableHeader.Title": "Stick rolltable header to top?",
+    "BRT.Settings.StickRolltableHeader.Description": "If enabled, roll table header will no more scroll with content."
+
 }

--- a/lang/es-ES.json
+++ b/lang/es-ES.json
@@ -33,5 +33,7 @@
     "BRT.Settings.RerollWarning.Title": "Reroll?",
     "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?",
     "BRT.Settings.StickRolltableHeader.Title": "Stick rolltable header to top?",
-    "BRT.Settings.StickRolltableHeader.Description": "If enabled, roll table header will no more scroll with content."
+    "BRT.Settings.StickRolltableHeader.Description": "If enabled, roll table header will no more scroll with content.",
+    "BRT.Settings.RollTableFromJournal.Title": "Add roll button to tables in journal entries?",
+    "BRT.Settings.RollTableFromJournal.Description": "If enabled, a roll button is added to linked tables in journal entries."
 }

--- a/lang/es-ES.json
+++ b/lang/es-ES.json
@@ -19,5 +19,7 @@
     "BRT.DrawResultPlural": "Obtiene {amount} resultados de {name}",
     "BRT.DrawResultSingular": "Obtiene {amount} resultado de {name}",
     "BRT.DrawResultZero": "Lanzar de {name}",
-    "BRT.DrawReroll": "Reroll"
+    "BRT.DrawReroll": "Reroll",
+    "BRT.Settings.RerollButtons.Title":"Show reroll buttons",
+    "BRT.Settings.RerollButtons.Description":"Display a Reroll button on each result card of a roll on a rolltable (only for newly created cards)"
 }

--- a/lang/es-ES.json
+++ b/lang/es-ES.json
@@ -20,6 +20,16 @@
     "BRT.DrawResultSingular": "Obtiene {amount} resultado de {name}",
     "BRT.DrawResultZero": "Lanzar de {name}",
     "BRT.DrawReroll": "Reroll",
-    "BRT.Settings.RerollButtons.Title":"Show reroll buttons",
-    "BRT.Settings.RerollButtons.Description":"Display a Reroll button on each result card of a roll on a rolltable (only for newly created cards)"
+    "BRT.Settings.RerollButtons.Title": "Show Reroll buttons",
+    "BRT.Settings.RerollButtons.Description": "Display a Reroll button on each result card of a roll on a rolltable (only for newly created cards). Work only on loot chat card or if condensed roll output is enabled. Default tables are not affected.",
+    "BRT.Settings.ShowWarningBeforeReroll.Title": "Confirm reroll ?",
+    "BRT.Settings.ShowWarningBeforeReroll.Description": "Show a confirm dialog before reroll message content.",
+    "BRT.Settings.UseCondensedBetterRoll.Title": "Use condensed roll output",
+    "BRT.Settings.UseCondensedBetterRoll.Description": "If enabled, this will aggregate same output with a multiplier to save space. This option may speed up rolltable draws. Default tables are not affected.",
+    "BRT.Settings.AddRollInRolltableContextMenu.Title": "Roll from rolltable contextmenu",
+    "BRT.Settings.AddRollInRolltableContextMenu.Description": "Add an option in rolltable's contextmenu to roll table without opening it. Work on all table type.",
+    "BRT.Settings.AddRollInCompediumContextMenu.Title": "Roll from compendium contextmenu",
+    "BRT.Settings.AddRollInCompediumContextMenu.Description": "Add an option in compendium's contextmenu to roll on this compendium without creating rolltable from it. Work on all non-empty compendiums.",
+    "BRT.Settings.RerollWarning.Title": "Reroll?",
+    "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?"
 }

--- a/lang/es-ES.json
+++ b/lang/es-ES.json
@@ -31,5 +31,7 @@
     "BRT.Settings.AddRollInCompediumContextMenu.Title": "Roll from compendium contextmenu",
     "BRT.Settings.AddRollInCompediumContextMenu.Description": "Add an option in compendium's contextmenu to roll on this compendium without creating rolltable from it. Work on all non-empty compendiums.",
     "BRT.Settings.RerollWarning.Title": "Reroll?",
-    "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?"
+    "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?",
+    "BRT.Settings.StickRolltableHeader.Title": "Stick rolltable header to top?",
+    "BRT.Settings.StickRolltableHeader.Description": "If enabled, roll table header will no more scroll with content."
 }

--- a/lang/es-ES.json
+++ b/lang/es-ES.json
@@ -18,5 +18,6 @@
     "BRT.LootRollAmountPlaceholder" : "Lanzar por la tabla al completo múltiples veces",
     "BRT.DrawResultPlural": "Obtiene {amount} resultados de {name}",
     "BRT.DrawResultSingular": "Obtiene {amount} resultado de {name}",
-    "BRT.DrawResultZero": "Lanzar de {name}"
+    "BRT.DrawResultZero": "Lanzar de {name}",
+    "BRT.DrawReroll": "Reroll"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -19,5 +19,7 @@
     "BRT.DrawResultPlural": "Vous avez tiré {amount} résultats de {name}",
     "BRT.DrawResultSingular": "Vous avez tiré {amount} résultat de {name}",
     "BRT.DrawResultZero": "Tirage sur {name}",
-    "BRT.DrawReroll": "Relancer"
+    "BRT.DrawReroll": "Relancer",
+    "BRT.Settings.RerollButtons.Title":"Afficher les boutons pour relancer",
+    "BRT.Settings.RerollButtons.Description": "Affiche un bouton Relancer sur chaque message de résultat d'un jet sur une table (uniquement pour les nouveaux messages)"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -31,5 +31,7 @@
     "BRT.Settings.AddRollInCompediumContextMenu.Title": "Lancer depuis le menu contextuel d'un compendium",
     "BRT.Settings.AddRollInCompediumContextMenu.Description": "Ajoute une option pour lancer un jet sur un compendium sans avoir à créer une table à partir de son contenu. Fonctionne sur tous les compendiums non vides.",
     "BRT.Settings.RerollWarning.Title": "Relancer ?",
-    "BRT.Settings.RerollWarning.Description": "Le contenu du message sera perdu. Êtes-vous sûr(e) de vouloir relancer ?"
+    "BRT.Settings.RerollWarning.Description": "Le contenu du message sera perdu. Êtes-vous sûr(e) de vouloir relancer ?",
+    "BRT.Settings.StickRolltableHeader.Title": "Figer l'entête des tables ?",
+    "BRT.Settings.StickRolltableHeader.Description": "Fige l'entête de tables afin que celui-ci soit toujours visible."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -21,5 +21,15 @@
     "BRT.DrawResultZero": "Tirage sur {name}",
     "BRT.DrawReroll": "Relancer",
     "BRT.Settings.RerollButtons.Title":"Afficher les boutons pour relancer",
-    "BRT.Settings.RerollButtons.Description": "Affiche un bouton Relancer sur chaque message de résultat d'un jet sur une table (uniquement pour les nouveaux messages)"
+    "BRT.Settings.RerollButtons.Description": "Affiche un bouton Relancer sur chaque message de résultat d'un jet sur une table (uniquement pour les nouveaux messages). Ne fonctionne que sur les tables de type Loot ou si les résultats sont condensés. Les tables par défaut ne sont pas affectées.",
+    "BRT.Settings.ShowWarningBeforeReroll.Title": "Confirmer la relance ?",
+    "BRT.Settings.ShowWarningBeforeReroll.Description": "Demande une confirmation avant de relancer le contenu d'un message.",
+    "BRT.Settings.UseCondensedBetterRoll.Title": "Condenser les résultats",
+    "BRT.Settings.UseCondensedBetterRoll.Description": "Si activé, les éléments identiques d'un résultat seront aggrégés avec un multiplicateur pour gagner de l'espace. Cette option peut accélérer le tirage aléatoire sur une table. Les tables par défaut ne sont pas affectées.",
+    "BRT.Settings.AddRollInRolltableContextMenu.Title": "Lancer depuis le menu contextuel d'une table",
+    "BRT.Settings.AddRollInRolltableContextMenu.Description": "Ajoute une option pour lancer un jet sur une table sans avoir à l'ouvrir. Fonctionne sur tous les types de tables.",
+    "BRT.Settings.AddRollInCompediumContextMenu.Title": "Lancer depuis le menu contextuel d'un compendium",
+    "BRT.Settings.AddRollInCompediumContextMenu.Description": "Ajoute une option pour lancer un jet sur un compendium sans avoir à créer une table à partir de son contenu. Fonctionne sur tous les compendiums non vides.",
+    "BRT.Settings.RerollWarning.Title": "Relancer ?",
+    "BRT.Settings.RerollWarning.Description": "Le contenu du message sera perdu. Êtes-vous sûr(e) de vouloir relancer ?"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -33,5 +33,7 @@
     "BRT.Settings.RerollWarning.Title": "Relancer ?",
     "BRT.Settings.RerollWarning.Description": "Le contenu du message sera perdu. Êtes-vous sûr(e) de vouloir relancer ?",
     "BRT.Settings.StickRolltableHeader.Title": "Figer l'entête des tables ?",
-    "BRT.Settings.StickRolltableHeader.Description": "Fige l'entête de tables afin que celui-ci soit toujours visible."
+    "BRT.Settings.StickRolltableHeader.Description": "Fige l'entête de tables afin que celui-ci soit toujours visible.",
+    "BRT.Settings.RollTableFromJournal.Title": "Ajouter un bouton de lancer aux tables dans les journaux ?",
+    "BRT.Settings.RollTableFromJournal.Description": "Si activé, un bouton pour lancer un tirage sur une table est ajouté aux tables liées dans un journal."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -18,5 +18,6 @@
     "BRT.LootRollAmountPlaceholder" : "Jette un jet sur l'intégralité de la table plusieurs fois",
     "BRT.DrawResultPlural": "Vous avez tiré {amount} résultats de {name}",
     "BRT.DrawResultSingular": "Vous avez tiré {amount} résultat de {name}",
-    "BRT.DrawResultZero": "Tirage sur {name}"
+    "BRT.DrawResultZero": "Tirage sur {name}",
+    "BRT.DrawReroll": "Relancer"
 }

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -33,5 +33,7 @@
     "BRT.Settings.RerollWarning.Title": "Reroll?",
     "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?",
     "BRT.Settings.StickRolltableHeader.Title": "Stick rolltable header to top?",
-    "BRT.Settings.StickRolltableHeader.Description": "If enabled, roll table header will no more scroll with content."
+    "BRT.Settings.StickRolltableHeader.Description": "If enabled, roll table header will no more scroll with content.",
+    "BRT.Settings.RollTableFromJournal.Title": "Add roll button to tables in journal entries?",
+    "BRT.Settings.RollTableFromJournal.Description": "If enabled, a roll button is added to linked tables in journal entries."
 }

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -19,5 +19,7 @@
     "BRT.DrawResultPlural": "{name}의 결과로 선택된 건 {amount}입니다",
     "BRT.DrawResultSingular": "{name}의 결과로 선택된 건 {amount}입니다",
     "BRT.DrawResultZero": "{name}에서 굴림",
-    "BRT.DrawReroll": "Reroll"
+    "BRT.DrawReroll": "Reroll",
+    "BRT.Settings.RerollButtons.Title":"Show reroll buttons",
+    "BRT.Settings.RerollButtons.Description":"Display a Reroll button on each result card of a roll on a rolltable (only for newly created cards)"
 }

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -31,5 +31,7 @@
     "BRT.Settings.AddRollInCompediumContextMenu.Title": "Roll from compendium contextmenu",
     "BRT.Settings.AddRollInCompediumContextMenu.Description": "Add an option in compendium's contextmenu to roll on this compendium without creating rolltable from it. Work on all non-empty compendiums.",
     "BRT.Settings.RerollWarning.Title": "Reroll?",
-    "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?"
+    "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?",
+    "BRT.Settings.StickRolltableHeader.Title": "Stick rolltable header to top?",
+    "BRT.Settings.StickRolltableHeader.Description": "If enabled, roll table header will no more scroll with content."
 }

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -20,6 +20,16 @@
     "BRT.DrawResultSingular": "{name}의 결과로 선택된 건 {amount}입니다",
     "BRT.DrawResultZero": "{name}에서 굴림",
     "BRT.DrawReroll": "Reroll",
-    "BRT.Settings.RerollButtons.Title":"Show reroll buttons",
-    "BRT.Settings.RerollButtons.Description":"Display a Reroll button on each result card of a roll on a rolltable (only for newly created cards)"
+    "BRT.Settings.RerollButtons.Title": "Show Reroll buttons",
+    "BRT.Settings.RerollButtons.Description": "Display a Reroll button on each result card of a roll on a rolltable (only for newly created cards). Work only on loot chat card or if condensed roll output is enabled. Default tables are not affected.",
+    "BRT.Settings.ShowWarningBeforeReroll.Title": "Confirm reroll ?",
+    "BRT.Settings.ShowWarningBeforeReroll.Description": "Show a confirm dialog before reroll message content.",
+    "BRT.Settings.UseCondensedBetterRoll.Title": "Use condensed roll output",
+    "BRT.Settings.UseCondensedBetterRoll.Description": "If enabled, this will aggregate same output with a multiplier to save space. This option may speed up rolltable draws. Default tables are not affected.",
+    "BRT.Settings.AddRollInRolltableContextMenu.Title": "Roll from rolltable contextmenu",
+    "BRT.Settings.AddRollInRolltableContextMenu.Description": "Add an option in rolltable's contextmenu to roll table without opening it. Work on all table type.",
+    "BRT.Settings.AddRollInCompediumContextMenu.Title": "Roll from compendium contextmenu",
+    "BRT.Settings.AddRollInCompediumContextMenu.Description": "Add an option in compendium's contextmenu to roll on this compendium without creating rolltable from it. Work on all non-empty compendiums.",
+    "BRT.Settings.RerollWarning.Title": "Reroll?",
+    "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?"
 }

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -18,5 +18,6 @@
     "BRT.LootRollAmountPlaceholder" : "표 전체를 여러 번 굴림(수식 추가)",
     "BRT.DrawResultPlural": "{name}의 결과로 선택된 건 {amount}입니다",
     "BRT.DrawResultSingular": "{name}의 결과로 선택된 건 {amount}입니다",
-    "BRT.DrawResultZero": "{name}에서 굴림"
+    "BRT.DrawResultZero": "{name}에서 굴림",
+    "BRT.DrawReroll": "Reroll"
 }

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -33,5 +33,7 @@
     "BRT.Settings.RerollWarning.Title": "Reroll?",
     "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?",
     "BRT.Settings.StickRolltableHeader.Title": "Stick rolltable header to top?",
-    "BRT.Settings.StickRolltableHeader.Description": "If enabled, roll table header will no more scroll with content."
+    "BRT.Settings.StickRolltableHeader.Description": "If enabled, roll table header will no more scroll with content.",
+    "BRT.Settings.RollTableFromJournal.Title": "Add roll button to tables in journal entries?",
+    "BRT.Settings.RollTableFromJournal.Description": "If enabled, a roll button is added to linked tables in journal entries."
 }

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -20,6 +20,16 @@
     "BRT.DrawResultSingular": "Sacar {amount} resultado de {name}",
     "BRT.DrawResultZero": "Rolagem em {name}",
     "BRT.DrawReroll": "Reroll",
-    "BRT.Settings.RerollButtons.Title":"Show reroll buttons",
-    "BRT.Settings.RerollButtons.Description":"Display a Reroll button on each result card of a roll on a rolltable (only for newly created cards)"
+    "BRT.Settings.RerollButtons.Title": "Show Reroll buttons",
+    "BRT.Settings.RerollButtons.Description": "Display a Reroll button on each result card of a roll on a rolltable (only for newly created cards). Work only on loot chat card or if condensed roll output is enabled. Default tables are not affected.",
+    "BRT.Settings.ShowWarningBeforeReroll.Title": "Confirm reroll ?",
+    "BRT.Settings.ShowWarningBeforeReroll.Description": "Show a confirm dialog before reroll message content.",
+    "BRT.Settings.UseCondensedBetterRoll.Title": "Use condensed roll output",
+    "BRT.Settings.UseCondensedBetterRoll.Description": "If enabled, this will aggregate same output with a multiplier to save space. This option may speed up rolltable draws. Default tables are not affected.",
+    "BRT.Settings.AddRollInRolltableContextMenu.Title": "Roll from rolltable contextmenu",
+    "BRT.Settings.AddRollInRolltableContextMenu.Description": "Add an option in rolltable's contextmenu to roll table without opening it. Work on all table type.",
+    "BRT.Settings.AddRollInCompediumContextMenu.Title": "Roll from compendium contextmenu",
+    "BRT.Settings.AddRollInCompediumContextMenu.Description": "Add an option in compendium's contextmenu to roll on this compendium without creating rolltable from it. Work on all non-empty compendiums.",
+    "BRT.Settings.RerollWarning.Title": "Reroll?",
+    "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?"
 }

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -31,5 +31,7 @@
     "BRT.Settings.AddRollInCompediumContextMenu.Title": "Roll from compendium contextmenu",
     "BRT.Settings.AddRollInCompediumContextMenu.Description": "Add an option in compendium's contextmenu to roll on this compendium without creating rolltable from it. Work on all non-empty compendiums.",
     "BRT.Settings.RerollWarning.Title": "Reroll?",
-    "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?"
+    "BRT.Settings.RerollWarning.Description": "Message content will be lost. Are you sure you want to reroll?",
+    "BRT.Settings.StickRolltableHeader.Title": "Stick rolltable header to top?",
+    "BRT.Settings.StickRolltableHeader.Description": "If enabled, roll table header will no more scroll with content."
 }

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -19,5 +19,7 @@
     "BRT.DrawResultPlural": "Sacar {amount} resultados de {name}",
     "BRT.DrawResultSingular": "Sacar {amount} resultado de {name}",
     "BRT.DrawResultZero": "Rolagem em {name}",
-    "BRT.DrawReroll": "Reroll"
+    "BRT.DrawReroll": "Reroll",
+    "BRT.Settings.RerollButtons.Title":"Show reroll buttons",
+    "BRT.Settings.RerollButtons.Description":"Display a Reroll button on each result card of a roll on a rolltable (only for newly created cards)"
 }

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -18,5 +18,6 @@
     "BRT.LootRollAmountPlaceholder" : "Role a tabela inteira várias vezes",
     "BRT.DrawResultPlural": "Sacar {amount} resultados de {name}",
     "BRT.DrawResultSingular": "Sacar {amount} resultado de {name}",
-    "BRT.DrawResultZero": "Rolagem em {name}"
+    "BRT.DrawResultZero": "Rolagem em {name}",
+    "BRT.DrawReroll": "Reroll"
 }

--- a/scripts/better-table-view.js
+++ b/scripts/better-table-view.js
@@ -11,18 +11,31 @@ export class BetterRT {
 
         let tableViewClass = tableElement.getElementsByClassName(tableClassName)[0];
 
-        /*
+
         if (game.settings.get(BRTCONFIG.NAMESPACE, BRTCONFIG.STICK_ROLLTABLE_HEADER)) {
             const header = $(html).find("section.results ol li:first-child");
             // we need to use <ol> parent to preserve styling
             const newHeader = header.clone();
-            newHeader.find(".create-result").click(async (event) => rollTabe.update() );
-            newHeader.find(".normalize-results").click((event) => );
             header.remove();
+
+            newHeader.find("a.create-result")[0].onclick = async (event) => {
+                event.preventDefault();
+                if (!game.keyboard.isCtrl()) {
+                    await rollTableConfig._onCreateResult(event);
+                } else {
+                    for (let i; i < 10; i++)
+                        await rollTableConfig._onCreateResult(event);
+                }
+            };
+
+            newHeader.find("a.normalize-results")[0].onclick = async (event) => {
+                event.preventDefault();
+                await rollTableConfig._onNormalizeResults(event);
+            };
+
             $(html).find("section.results").prepend($('<ol class="table-results">').append(newHeader));
 
         }
-        */
 
         /** height size increase by type: */
         let addHeight = 0;

--- a/scripts/better-table-view.js
+++ b/scripts/better-table-view.js
@@ -20,11 +20,12 @@ export class BetterRT {
 
             newHeader.find("a.create-result")[0].onclick = async (event) => {
                 event.preventDefault();
-                if (!game.keyboard.isCtrl()) {
+                if (!game.keyboard.isCtrl(event)) {
                     await rollTableConfig._onCreateResult(event);
                 } else {
-                    for (let i; i < 10; i++)
+                    for (let i=0; i < 10; i++) {
                         await rollTableConfig._onCreateResult(event);
+                    }
                 }
             };
 

--- a/scripts/better-table-view.js
+++ b/scripts/better-table-view.js
@@ -11,12 +11,18 @@ export class BetterRT {
 
         let tableViewClass = tableElement.getElementsByClassName(tableClassName)[0];
 
+        /*
         if (game.settings.get(BRTCONFIG.NAMESPACE, BRTCONFIG.STICK_ROLLTABLE_HEADER)) {
             const header = $(html).find("section.results ol li:first-child");
             // we need to use <ol> parent to preserve styling
-            $(html).find("section.results").prepend($('<ol class="table-results">').append(header.clone()));
+            const newHeader = header.clone();
+            newHeader.find(".create-result").click(async (event) => rollTabe.update() );
+            newHeader.find(".normalize-results").click((event) => );
             header.remove();
+            $(html).find("section.results").prepend($('<ol class="table-results">').append(newHeader));
+
         }
+        */
 
         /** height size increase by type: */
         let addHeight = 0;

--- a/scripts/better-table-view.js
+++ b/scripts/better-table-view.js
@@ -11,6 +11,13 @@ export class BetterRT {
 
         let tableViewClass = tableElement.getElementsByClassName(tableClassName)[0];
 
+        if (game.settings.get(BRTCONFIG.NAMESPACE, BRTCONFIG.STICK_ROLLTABLE_HEADER)) {
+            const header = $(html).find("section.results ol li:first-child");
+            // we need to use <ol> parent to preserve styling
+            $(html).find("section.results").prepend($('<ol class="table-results">').append(header.clone()));
+            header.remove();
+        }
+
         /** height size increase by type: */
         let addHeight = 0;
         switch (selectedTableType) {

--- a/scripts/better-tables.js
+++ b/scripts/better-tables.js
@@ -281,7 +281,7 @@ export class BetterTables {
      * @returns {Promise<void>}
      */
     static async handleChatMessageButtons(message, html) {
-        if (!game.user.isGM) return;
+        if (!game.user.isGM || !game.settings.get(BRTCONFIG.NAMESPACE, BRTCONFIG.SHOW_REROLL_BUTTONS)) return;
 
         $(html).find(".brt-card-buttons button").each(async function(index, button) {
             const id = $(button).data("id");

--- a/scripts/better-tables.js
+++ b/scripts/better-tables.js
@@ -220,27 +220,37 @@ export class BetterTables {
     }
 
     /**
-     *
-     * @param {String} compendium ID of the compendium to roll
+     * Create card content from compendium content
+      * @param {String} compendium compendium name
+     * @returns {Promise<{flavor: string, sound: string, user: *, content: *}>}
      */
-    static async menuCallBackRollCompendium(compendium) {
+    static async rollCompendiumAsRolltable(compendium) {
         // Get random item from compendium
         const item = await getRandomItemFromCompendium(compendium);
 
         // prepare card data
         const fontSize = Math.max(60, 100 - Math.max(0, item.name.length - 27) * 2);
         const chatCardData = {
+            compendium: compendium,
             itemsData: [
                 { item: item, quantity: 1, fontSize: fontSize }
             ]
         };
         const cardHtml = await renderTemplate("modules/better-rolltables/templates/loot-chat-card.hbs", chatCardData);
-        const chatData = {
+        return {
             flavor: `Rolled from compendium ${item.pack}`,
             sound: "sounds/dice.wav",
             user: game.user.data._id,
             content: cardHtml
         };
+    }
+
+    /**
+     *
+     * @param {String} compendium ID of the compendium to roll
+     */
+    static async menuCallBackRollCompendium(compendium) {
+        const chatData = await BetterTables.rollCompendiumAsRolltable(compendium);
         ChatMessage.create(chatData);
     }
 }

--- a/scripts/better-tables.js
+++ b/scripts/better-tables.js
@@ -99,10 +99,15 @@ export class BetterTables {
         return await brtBuilder.betterRoll();
     }
 
-    async betterTableRoll(tableEntity) {
+    async betterTableRoll(tableEntity, options) {
         const brtBuilder = new BRTBuilder(tableEntity);
         const results = await brtBuilder.betterRoll();
-        await brtBuilder.createChatCard(results);
+
+        const br = new BetterResults(results);
+        const betterResults = await br.buildResults(tableEntity);
+
+        const lootChatCard = new LootChatCard(betterResults, undefined);
+        await lootChatCard.createChatCard(tableEntity);
     }
 
 

--- a/scripts/better-tables.js
+++ b/scripts/better-tables.js
@@ -4,7 +4,9 @@ import { StoryBuilder } from './story/story-builder.js';
 import { StoryChatCard } from './story/story-chat-card.js';
 import { BRTBuilder } from './core/brt-builder.js';
 import { BetterResults } from './core/brt-table-results.js';
+import { getRandomItemFromCompendium } from "./core/utils.js";
 import { BRTCONFIG } from "./core/config.js";
+
 
 export class BetterTables {
     __constructor() {
@@ -175,6 +177,14 @@ export class BetterTables {
                 BetterTables.menuCallBackCreateTable(li.data('pack'));
             }
         });
+
+        options.push({
+            "name": "Roll on compendium",
+            "icon": '<i class="fas fa-dice-d20"></i>',
+            "callback": li => {
+                BetterTables.menuCallBackRollCompendium(li.data('pack'));
+            }
+        });
     }
 
     /**
@@ -207,5 +217,30 @@ export class BetterTables {
     static async menuCallBackRollTable(rolltable_id){
         const rolltable = game.tables.get(rolltable_id);
         await game.betterTables.betterTableRoll(rolltable);
+    }
+
+    /**
+     *
+     * @param {String} compendium ID of the compendium to roll
+     */
+    static async menuCallBackRollCompendium(compendium) {
+        // Get random item from compendium
+        const item = await getRandomItemFromCompendium(compendium);
+
+        // prepare card data
+        const fontSize = Math.max(60, 100 - Math.max(0, item.name.length - 27) * 2);
+        const chatCardData = {
+            itemsData: [
+                { item: item, quantity: 1, fontSize: fontSize }
+            ]
+        };
+        const cardHtml = await renderTemplate("modules/better-rolltables/templates/loot-chat-card.hbs", chatCardData);
+        const chatData = {
+            flavor: `Rolled from compendium ${item.pack}`,
+            sound: "sounds/dice.wav",
+            user: game.user.data._id,
+            content: cardHtml
+        };
+        ChatMessage.create(chatData);
     }
 }

--- a/scripts/better-tables.js
+++ b/scripts/better-tables.js
@@ -179,9 +179,33 @@ export class BetterTables {
 
     /**
      *
-     * @param {String} compendium
+     * @param {String} compendium_id
      */
     static async menuCallBackCreateTable(compendium_id){
         await game.betterTables.createTableFromCompendium('BRT | '+ compendium_id,compendium_id);
+    }
+
+    /**
+     * Add a roll option in context menu of rolltables
+     * @param {html} html
+     * @param {Array} options
+     */
+    static async enhanceRolltableContextMenu(html, options) {
+        options.push({
+            "name": "Roll table",
+            "icon": '<i class="fas fa-dice-d20"></i>',
+            "callback": li => {
+                BetterTables.menuCallBackRollTable(li.data("entityId"));
+            }
+        });
+    }
+
+    /**
+     *
+     * @param {String} rolltable_id ID of the rolltable to roll
+     */
+    static async menuCallBackRollTable(rolltable_id){
+        const rolltable = game.tables.get(rolltable_id);
+        await game.betterTables.betterTableRoll(rolltable);
     }
 }

--- a/scripts/better-tables.js
+++ b/scripts/better-tables.js
@@ -110,7 +110,6 @@ export class BetterTables {
         await lootChatCard.createChatCard(tableEntity);
     }
 
-
     /**
      * Create a new RollTable by extracting entries from a compendium.
      *

--- a/scripts/brt-main.js
+++ b/scripts/brt-main.js
@@ -36,7 +36,7 @@ Hooks.once("ready", async () => {
 
 // refresh spell cache for random spell scroll generation on compendium updates
 Hooks.on("updateCompendium", async function (pack, documents, option, userId) {
-  if (pack === game.settings.get("better-rolltables", "default-spell-compendium")) {
+  if (pack === game.settings.get(BRTCONFIG.NAMESPACE, BRTCONFIG.SPELL_COMPENDIUM_KEY)) {
     await game.betterTables.updateSpellCache();
   }
 });

--- a/scripts/brt-main.js
+++ b/scripts/brt-main.js
@@ -38,6 +38,7 @@ Hooks.on("updateCompendium", async function (pack, documents, option, userId) {
 
 Hooks.on("renderRollTableConfig", BetterRT.enhanceRollTableView);
 Hooks.on('getCompendiumDirectoryEntryContext', BetterTables.enhanceCompendiumContextMenu);
+Hooks.on('getRollTableDirectoryEntryContext', BetterTables.enhanceRolltableContextMenu);
 
 function registerSettings() {
   let defaultLootSheet = "dnd5e.LootSheet5eNPC";

--- a/scripts/brt-main.js
+++ b/scripts/brt-main.js
@@ -56,29 +56,6 @@ Hooks.once("ready", async () => {
   }
 });
 
-// refresh spell cache for random spell scroll generation on compendium updates
-Hooks.on("updateCompendium", async function (pack, documents, option, userId) {
-  if (pack === game.settings.get(BRTCONFIG.NAMESPACE, BRTCONFIG.SPELL_COMPENDIUM_KEY)) {
-    await game.betterTables.updateSpellCache();
-  }
-});
-
-Hooks.on("renderRollTableConfig", BetterRT.enhanceRollTableView);
-Hooks.on('getCompendiumDirectoryEntryContext', BetterTables.enhanceCompendiumContextMenu);
-Hooks.on('getRollTableDirectoryEntryContext', BetterTables.enhanceRolltableContextMenu);
-
-Hooks.on('renderChatMessage', async (message, html, data) => {
-  if (game.settings.get(BRTCONFIG.NAMESPACE, BRTCONFIG.SHOW_REROLL_BUTTONS)) {
-    BetterTables.handleChatMessageButtons(message, html)
-  }
-});
-
-Hooks.on('renderDocumentSheet', async (sheet, html, data) => {
-  if (game.user.isGM && game.settings.get(BRTCONFIG.NAMESPACE, BRTCONFIG.ROLL_TABLE_FROM_JOURNAL)) {
-    BetterTables.handleRolltableLink(sheet, html, data)
-  }
-});
-
 function registerSettings() {
   let defaultLootSheet = "dnd5e.LootSheet5eNPC";
   let defaultSpellCompendium = "dnd5e.spells";

--- a/scripts/brt-main.js
+++ b/scripts/brt-main.js
@@ -32,6 +32,28 @@ Hooks.once("ready", async () => {
   }
 
   await game.betterTables.updateSpellCache();
+
+  // refresh spell cache for random spell scroll generation on compendium updates
+  Hooks.on("updateCompendium", async function (pack, documents, option, userId) {
+    if (pack === game.settings.get(BRTCONFIG.NAMESPACE, BRTCONFIG.SPELL_COMPENDIUM_KEY)) {
+      await game.betterTables.updateSpellCache();
+    }
+  });
+
+  Hooks.on("renderRollTableConfig", BetterRT.enhanceRollTableView);
+  Hooks.on('getCompendiumDirectoryEntryContext', BetterTables.enhanceCompendiumContextMenu);
+  Hooks.on('getRollTableDirectoryEntryContext', BetterTables.enhanceRolltableContextMenu);
+  Hooks.on('renderChatMessage', BetterTables.handleChatMessageButtons);
+
+  Hooks.on('renderDocumentSheet', async (sheet, html, data) => {
+    if (game.user.isGM && game.settings.get(BRTCONFIG.NAMESPACE, BRTCONFIG.ROLL_TABLE_FROM_JOURNAL)) {
+      BetterTables.handleRolltableLink(sheet, html, data)
+    }
+  });
+
+  if (game.system.id === "dnd5e") {
+    Hooks.on('renderActorSheet5eCharacter', BetterTables.handleChatMessageButtons);
+  }
 });
 
 // refresh spell cache for random spell scroll generation on compendium updates

--- a/scripts/brt-main.js
+++ b/scripts/brt-main.js
@@ -44,6 +44,7 @@ Hooks.on("updateCompendium", async function (pack, documents, option, userId) {
 Hooks.on("renderRollTableConfig", BetterRT.enhanceRollTableView);
 Hooks.on('getCompendiumDirectoryEntryContext', BetterTables.enhanceCompendiumContextMenu);
 Hooks.on('getRollTableDirectoryEntryContext', BetterTables.enhanceRolltableContextMenu);
+Hooks.on('renderChatMessage', BetterTables.handleChatMessageButtons);
 
 function registerSettings() {
   let defaultLootSheet = "dnd5e.LootSheet5eNPC";

--- a/scripts/brt-main.js
+++ b/scripts/brt-main.js
@@ -77,6 +77,14 @@ function registerSettings() {
     default: defaultSpellCompendium,
     type: String
   });
+
+  game.settings.register(BRTCONFIG.NAMESPACE, BRTCONFIG.SHOW_REROLL_BUTTONS, {
+    name: i18n("BRT.Settings.RerollButtons.Title"),
+    hint: i18n("BRT.Settings.RerollButtons.Description"),
+    config: true,
+    default: false,
+    type: Boolean
+  });
 }
 
 

--- a/scripts/brt-main.js
+++ b/scripts/brt-main.js
@@ -78,9 +78,41 @@ function registerSettings() {
     type: String
   });
 
+  game.settings.register(BRTCONFIG.NAMESPACE, BRTCONFIG.USE_CONDENSED_BETTERROLL, {
+    name: i18n("BRT.Settings.UseCondensedBetterRoll.Title"),
+    hint: i18n("BRT.Settings.UseCondensedBetterRoll.Description"),
+    config: true,
+    default: false,
+    type: Boolean
+  });
+
   game.settings.register(BRTCONFIG.NAMESPACE, BRTCONFIG.SHOW_REROLL_BUTTONS, {
     name: i18n("BRT.Settings.RerollButtons.Title"),
     hint: i18n("BRT.Settings.RerollButtons.Description"),
+    config: true,
+    default: false,
+    type: Boolean
+  });
+
+  game.settings.register(BRTCONFIG.NAMESPACE, BRTCONFIG.SHOW_WARNING_BEFORE_REROLL, {
+    name: i18n("BRT.Settings.ShowWarningBeforeReroll.Title"),
+    hint: i18n("BRT.Settings.ShowWarningBeforeReroll.Description"),
+    config: true,
+    default: false,
+    type: Boolean
+  });
+
+  game.settings.register(BRTCONFIG.NAMESPACE, BRTCONFIG.ADD_ROLL_IN_ROLLTABLE_CONTEXTMENU, {
+    name: i18n("BRT.Settings.AddRollInRolltableContextMenu.Title"),
+    hint: i18n("BRT.Settings.AddRollInRolltableContextMenu.Description"),
+    config: true,
+    default: false,
+    type: Boolean
+  });
+
+  game.settings.register(BRTCONFIG.NAMESPACE, BRTCONFIG.ADD_ROLL_IN_COMPENDIUM_CONTEXTMENU, {
+    name: i18n("BRT.Settings.AddRollInCompediumContextMenu.Title"),
+    hint: i18n("BRT.Settings.AddRollInCompediumContextMenu.Description"),
     config: true,
     default: false,
     type: Boolean

--- a/scripts/brt-main.js
+++ b/scripts/brt-main.js
@@ -17,6 +17,11 @@ Hooks.once("init", () => {
     return options.inverse(this);
   });
 
+  /** checks if the first argument is greater than the second argument */
+  Handlebars.registerHelper('ifgt', function (v1, v2, options) {
+    return v1 > v2 ? options.fn(this) : options.inverse(this);
+  });
+
   registerSettings();
   game.betterTables = new BetterTables();
 });

--- a/scripts/brt-main.js
+++ b/scripts/brt-main.js
@@ -44,7 +44,18 @@ Hooks.on("updateCompendium", async function (pack, documents, option, userId) {
 Hooks.on("renderRollTableConfig", BetterRT.enhanceRollTableView);
 Hooks.on('getCompendiumDirectoryEntryContext', BetterTables.enhanceCompendiumContextMenu);
 Hooks.on('getRollTableDirectoryEntryContext', BetterTables.enhanceRolltableContextMenu);
-Hooks.on('renderChatMessage', BetterTables.handleChatMessageButtons);
+
+Hooks.on('renderChatMessage', async (message, html, data) => {
+  if (game.settings.get(BRTCONFIG.NAMESPACE, BRTCONFIG.SHOW_REROLL_BUTTONS)) {
+    BetterTables.handleChatMessageButtons(message, html)
+  }
+});
+
+Hooks.on('renderDocumentSheet', async (sheet, html, data) => {
+  if (game.user.isGM && game.settings.get(BRTCONFIG.NAMESPACE, BRTCONFIG.ROLL_TABLE_FROM_JOURNAL)) {
+    BetterTables.handleRolltableLink(sheet, html, data)
+  }
+});
 
 function registerSettings() {
   let defaultLootSheet = "dnd5e.LootSheet5eNPC";
@@ -125,6 +136,15 @@ function registerSettings() {
     default: false,
     type: Boolean
   });
+
+  game.settings.register(BRTCONFIG.NAMESPACE, BRTCONFIG.ROLL_TABLE_FROM_JOURNAL, {
+    name: i18n("BRT.Settings.RollTableFromJournal.Title"),
+    hint: i18n("BRT.Settings.RollTableFromJournal.Description"),
+    config: true,
+    default: false,
+    type: Boolean
+  });
+
 }
 
 

--- a/scripts/brt-main.js
+++ b/scripts/brt-main.js
@@ -117,6 +117,14 @@ function registerSettings() {
     default: false,
     type: Boolean
   });
+
+  game.settings.register(BRTCONFIG.NAMESPACE, BRTCONFIG.STICK_ROLLTABLE_HEADER, {
+    name: i18n("BRT.Settings.StickRolltableHeader.Title"),
+    hint: i18n("BRT.Settings.StickRolltableHeader.Description"),
+    config: true,
+    default: false,
+    type: Boolean
+  });
 }
 
 

--- a/scripts/core/config.js
+++ b/scripts/core/config.js
@@ -21,6 +21,7 @@ BRTCONFIG.USE_CONDENSED_BETTERROLL = "use-condensed-betterroll";
 BRTCONFIG.ADD_ROLL_IN_COMPENDIUM_CONTEXTMENU = "add-roll-on-compendium-contextmenu";
 BRTCONFIG.ADD_ROLL_IN_ROLLTABLE_CONTEXTMENU = "add-roll-on-rolltable-contextmenu";
 BRTCONFIG.SHOW_WARNING_BEFORE_REROLL = "show-warning-before-reroll";
+BRTCONFIG.STICK_ROLLTABLE_HEADER = "stick-rolltable-header";
 
 //in fp2e quantity is in data.data.quantity.value , in 5e data.data.quantity  
 BRTCONFIG.QUANTITY_PROPERTY_PATH = "data.quantity";

--- a/scripts/core/config.js
+++ b/scripts/core/config.js
@@ -17,6 +17,10 @@ BRTCONFIG.TABLE_TYPE_STORY = "story";
 BRTCONFIG.SPELL_COMPENDIUM_KEY = "default-spell-compendium";
 BRTCONFIG.LOOT_SHEET_TO_USE_KEY = "loot-sheet-to-use";
 BRTCONFIG.SHOW_REROLL_BUTTONS = "show-reroll-buttons";
+BRTCONFIG.USE_CONDENSED_BETTERROLL = "use-condensed-betterroll";
+BRTCONFIG.ADD_ROLL_IN_COMPENDIUM_CONTEXTMENU = "add-roll-on-compendium-contextmenu";
+BRTCONFIG.ADD_ROLL_IN_ROLLTABLE_CONTEXTMENU = "add-roll-on-rolltable-contextmenu";
+BRTCONFIG.SHOW_WARNING_BEFORE_REROLL = "show-warning-before-reroll";
 
 //in fp2e quantity is in data.data.quantity.value , in 5e data.data.quantity  
 BRTCONFIG.QUANTITY_PROPERTY_PATH = "data.quantity";

--- a/scripts/core/config.js
+++ b/scripts/core/config.js
@@ -22,6 +22,7 @@ BRTCONFIG.ADD_ROLL_IN_COMPENDIUM_CONTEXTMENU = "add-roll-on-compendium-contextme
 BRTCONFIG.ADD_ROLL_IN_ROLLTABLE_CONTEXTMENU = "add-roll-on-rolltable-contextmenu";
 BRTCONFIG.SHOW_WARNING_BEFORE_REROLL = "show-warning-before-reroll";
 BRTCONFIG.STICK_ROLLTABLE_HEADER = "stick-rolltable-header";
+BRTCONFIG.ROLL_TABLE_FROM_JOURNAL = "roll-table-from-journal";
 
 //in fp2e quantity is in data.data.quantity.value , in 5e data.data.quantity  
 BRTCONFIG.QUANTITY_PROPERTY_PATH = "data.quantity";

--- a/scripts/core/config.js
+++ b/scripts/core/config.js
@@ -16,6 +16,7 @@ BRTCONFIG.TABLE_TYPE_STORY = "story";
 
 BRTCONFIG.SPELL_COMPENDIUM_KEY = "default-spell-compendium";
 BRTCONFIG.LOOT_SHEET_TO_USE_KEY = "loot-sheet-to-use";
+BRTCONFIG.SHOW_REROLL_BUTTONS = "show-reroll-buttons";
 
 //in fp2e quantity is in data.data.quantity.value , in 5e data.data.quantity  
 BRTCONFIG.QUANTITY_PROPERTY_PATH = "data.quantity";

--- a/scripts/core/utils.js
+++ b/scripts/core/utils.js
@@ -46,3 +46,21 @@ export function separateIdComendiumName(stringWithComendium) {
  export async function getItemFromCompendium(item) {
      return findInCompendiumByName(item.collection, item.text);
 }
+
+/**
+ *
+ * @param {object} compendium reference to compendium to roll
+ * @returns {object} item from compendium
+ */
+export async function getRandomItemFromCompendium(compendium) {
+    const pack = game.packs.get(compendium);
+    if (!pack) return;
+    const size = pack.index.size;
+    if (size === 0) {
+        ui.notifications.warn(`Compendium ${pack.title} is empty.`);
+        return;
+    }
+    const randonIndex = Math.floor(Math.random() * size);
+    const randomItem = pack.index.contents[randonIndex];
+    return pack.getDocument(randomItem._id);
+}

--- a/scripts/loot/loot-chat-card.js
+++ b/scripts/loot/loot-chat-card.js
@@ -78,7 +78,7 @@ export class LootChatCard {
         return this.historyFolder;
     }
 
-    async createChatCard(table) {
+    async prepareCharCart(table) {
         await this.findOrCreateItems();
 
         let currencyString = "";
@@ -90,7 +90,9 @@ export class LootChatCard {
         const chatCardData = {
             tableData: table.data,
             itemsData: this.itemsData,
-            currency: currencyString
+            currency: currencyString,
+            compendium: table.pack,
+            id: table.id
         };
 
         const cardHtml = await renderTemplate("modules/better-rolltables/templates/loot-chat-card.hbs", chatCardData);
@@ -104,13 +106,16 @@ export class LootChatCard {
             flavorString = game.i18n.format('BRT.DrawResultZero', { name: table.data.name });
         }
 
-        let chatData = {
+        return {
             flavor: flavorString,
             sound: "sounds/dice.wav",
             user: game.user.data._id,
             content: cardHtml
         };
+    }
 
+    async createChatCard(table) {
+        const chatData = await this.prepareCharCart(table);
         addRollModeToChatData(chatData);
         ChatMessage.create(chatData);
     }

--- a/styles/brt.css
+++ b/styles/brt.css
@@ -36,3 +36,8 @@
   user-select: text;
   -moz-user-select: text;
 }
+
+/* Used to display a button to reroll card output */
+.roll-table-reroll-button {
+  margin-right: 5px;
+}

--- a/styles/brt.css
+++ b/styles/brt.css
@@ -41,3 +41,11 @@
 .roll-table-reroll-button {
   margin-right: 5px;
 }
+
+.roll-table-roll-link {
+  background: #DDD;
+  padding: 1px 2px;
+  margin-left: -1px;
+  border: 1px solid;
+  border-left: 0;
+}

--- a/templates/loot-chat-card.hbs
+++ b/templates/loot-chat-card.hbs
@@ -1,10 +1,15 @@
-<div class="table-draw">
+<div class="table-draw" {{#if this.compendium}}data-pack="{{this.compendium}}"{{/if}} {{#if this.id}}data-id="{{this.id}}"{{/if}}>
     {{#if tableData.description}}
     <div class="table-description">{{tableData.description}}</div>
     {{/if}}
     {{#if currency}}
     <div class="table-description" style="font-size: 15px; text-align: center; font-weight:bold;"> {{localize 'BRT.Currency'}}{{currency}}</div>
     {{/if}}
+    <div class="brt-card-buttons">
+        <button style="display:none" {{#if this.compendium}}data-pack="{{this.compendium}}"{{/if}} {{#if this.id}}data-id="{{this.id}}"{{/if}}>
+            {{localize 'BRT.DrawReroll'}}
+        </button>
+    </div>
 
     <ol class="table-results">
         {{#each itemsData as |itemData|}}
@@ -23,10 +28,4 @@
         </li>
         {{/each}}
     </ol>
-
-    <div class="brt-card-buttons">
-        <button style="display:none" {{#if this.compendium}}data-pack="{{this.compendium}}"{{/if}} {{#if this.id}}data-id="{{this.id}}"{{/if}}>
-            {{localize 'BRT.DrawReroll'}}
-        </button>
-    </div>
 </div>

--- a/templates/loot-chat-card.hbs
+++ b/templates/loot-chat-card.hbs
@@ -3,9 +3,7 @@
     <div class="table-description">{{tableData.description}}</div>
     {{/if}}
     {{#if currency}}
-    <div class="table-description" style="font-size: 15px; text-align: center;">
-        <strong>{{localize 'BRT.Currency'}}</strong>&nbsp;{{currency}}
-    </div>
+    <div class="table-description" style="font-size: 15px; text-align: center; font-weight:bold;"> {{localize 'BRT.Currency'}}{{currency}}</div>
     {{/if}}
 
     <ol class="table-results">

--- a/templates/loot-chat-card.hbs
+++ b/templates/loot-chat-card.hbs
@@ -23,4 +23,10 @@
         </li>
         {{/each}}
     </ol>
+
+    <div class="brt-card-buttons">
+        <button style="display:none" {{#if this.compendium}}data-pack="{{this.compendium}}"{{/if}} {{#if this.id}}data-id="{{this.id}}"{{/if}}>
+            {{localize 'BRT.DrawReroll'}}
+        </button>
+    </div>
 </div>

--- a/templates/loot-chat-card.hbs
+++ b/templates/loot-chat-card.hbs
@@ -5,11 +5,6 @@
     {{#if currency}}
     <div class="table-description" style="font-size: 15px; text-align: center; font-weight:bold;"> {{localize 'BRT.Currency'}}{{currency}}</div>
     {{/if}}
-    <div class="brt-card-buttons">
-        <button style="display:none" {{#if this.compendium}}data-pack="{{this.compendium}}"{{/if}} {{#if this.id}}data-id="{{this.id}}"{{/if}}>
-            {{localize 'BRT.DrawReroll'}}
-        </button>
-    </div>
 
     <ol class="table-results">
         {{#each itemsData as |itemData|}}

--- a/templates/loot-chat-card.hbs
+++ b/templates/loot-chat-card.hbs
@@ -20,7 +20,7 @@
                     {{/if}} data-id="{{itemData.item.id}}">
                     <i class="fas fa-suitcase"></i> {{itemData.item.name}}
                 </a>
-                <strong>&nbsp; &#xD7; {{itemData.quantity}}</strong>
+                {{#ifgt itemData.quantity 1 }}<strong>&nbsp; &#xD7; {{itemData.quantity}}</strong>{{/ifgt}}
             </div>
         </li>
         {{/each}}


### PR DESCRIPTION
This PR add a bunch of QoL features. Each feature is optional and is disabled by default to respect current behavior. English and French translations are up-to-date. _(Note: #99 must be merged before this one)_

# Reroll from message
A new button has been added on Better Table message to allow rerolling without having to reopen table or compendium! Message content is replace to avoid spamming chat. A warning can be enabled to prevent overwriting content. This feature is restricted to GM only, players won't see the button.
![reroll](https://user-images.githubusercontent.com/1334405/125740213-67c4c1d2-8019-40f6-af55-617a34114893.gif)

# Condensed Better Roll
Better Table roll will aggregatre output of same type on card to spare space and performance like Loot Table do. Quantity is no more specified if equals to 1.
![condensed better roll](https://user-images.githubusercontent.com/1334405/125739754-ac54c512-ed3f-4a9a-b5f4-a3e685205882.png)

# Stick rolltable header
A new option has been added to stick the header of rolltable to top. No more need to scroll again to top to add a new row!
![stick-header](https://user-images.githubusercontent.com/1334405/125765625-8a26e090-3280-4c9f-acc7-2a07bb799f08.gif)

# Roll tables from journal entries
A button is now append to linked rolltables in journal entries to roll table in one click!
![roll-from-journal](https://user-images.githubusercontent.com/1334405/125784632-fbd00474-17db-4e61-bee3-9f98401dafc8.gif)


Features introduced with PR #99 have now settings to be disabled (disabled by default).