### PR TITLE
Support manual roll modes

### DIFF
--- a/scripts/better-tables.js
+++ b/scripts/better-tables.js
@@ -24,20 +24,21 @@ export class BetterTables {
    * 
    * @param {*} tableEntity 
    */
-  async generateLoot (tableEntity) {
-    const brtBuilder = new BRTBuilder(tableEntity)
-    const results = await brtBuilder.betterRoll()
+  async generateLoot (tableEntity, options = null) {
+    const brtBuilder = new BRTBuilder(tableEntity),
+          results = await brtBuilder.betterRoll(),
+          br = new BetterResults(results),
+          betterResults = await br.buildResults(tableEntity),
+          currencyData = br.getCurrencyData(),
+          lootCreator = new LootCreator(betterResults, currencyData);
 
-    const br = new BetterResults(results);
-    const betterResults = await br.buildResults(tableEntity);
-    const currencyData = br.getCurrencyData();
-    const lootCreator = new LootCreator(betterResults, currencyData);
     await lootCreator.createActor(tableEntity);
     await lootCreator.addCurrenciesToActor();
     await lootCreator.addItemsToActor();
 
     if (game.settings.get(BRTCONFIG.NAMESPACE, BRTCONFIG.ALWAYS_SHOW_GENERATED_LOOT_AS_MESSAGE)) {
-      const lootChatCard = new LootChatCard(betterResults, currencyData);
+      const rollMode = (options && ('rollMode' in options)) ? options.rollMode : null;
+      const lootChatCard = new LootChatCard(betterResults, currencyData, rollMode);
       await lootChatCard.createChatCard(tableEntity);
     }
 }
@@ -76,15 +77,15 @@ export class BetterTables {
     return ui.notifications.info('Loot generation complete.');
   }
 
-  async generateChatLoot (tableEntity) {
-    const brtBuilder = new BRTBuilder(tableEntity)
-    const results = await brtBuilder.betterRoll()
+  async generateChatLoot (tableEntity, options = null) {
+    const rollMode = (options && ('rollMode' in options)) ? options.rollMode : null;
+    const brtBuilder = new BRTBuilder(tableEntity),
+          results = await brtBuilder.betterRoll(),
+          br = new BetterResults(results),
+          betterResults = await br.buildResults(tableEntity),
+          currencyData = br.getCurrencyData(),
+          lootChatCard = new LootChatCard(betterResults, currencyData, rollMode);
 
-    const br = new BetterResults(results)
-    const betterResults = await br.buildResults(tableEntity)
-    const currencyData = br.getCurrencyData()
-
-    const lootChatCard = new LootChatCard(betterResults, currencyData)
     await lootChatCard.createChatCard(tableEntity)
   }
 
@@ -111,7 +112,9 @@ export class BetterTables {
     return await brtBuilder.betterRoll()
   }
 
-  async betterTableRoll (tableEntity) {
+  async betterTableRoll (tableEntity, options = null) {
+    const rollMode = (options && ('rollMode' in options)) ? options.rollMode : null;
+
     const brtBuilder = new BRTBuilder(tableEntity)
     const results = await brtBuilder.betterRoll()
 
@@ -120,10 +123,10 @@ export class BetterTables {
       const betterResults = await br.buildResults(tableEntity)
       const currencyData = br.getCurrencyData()
 
-      const lootChatCard = new LootChatCard(betterResults, currencyData)
+      const lootChatCard = new LootChatCard(betterResults, currencyData, rollMode);
       await lootChatCard.createChatCard(tableEntity)
     } else {
-      await brtBuilder.createChatCard(results)
+      await brtBuilder.createChatCard(results, rollMode);
     }
   }
 

--- a/scripts/better-tables.js
+++ b/scripts/better-tables.js
@@ -20,51 +20,60 @@ export class BetterTables {
     return this._spellCache
   }
 
+  /**
+   * 
+   * @param {*} tableEntity 
+   */
   async generateLoot (tableEntity) {
     const brtBuilder = new BRTBuilder(tableEntity)
     const results = await brtBuilder.betterRoll()
 
-    const br = new BetterResults(results)
-    const betterResults = await br.buildResults(tableEntity)
-    const currencyData = br.getCurrencyData()
-    // console.log("++BETTER RESULTS ", betterResults);
-    // console.log("++ currencyData", currencyData);
-
-    const lootCreator = new LootCreator(betterResults, currencyData)
-    await lootCreator.createActor(tableEntity)
-    await lootCreator.addCurrenciesToActor()
-    await lootCreator.addItemsToActor()
+    const br = new BetterResults(results);
+    const betterResults = await br.buildResults(tableEntity);
+    const currencyData = br.getCurrencyData();
+    const lootCreator = new LootCreator(betterResults, currencyData);
+    await lootCreator.createActor(tableEntity);
+    await lootCreator.addCurrenciesToActor();
+    await lootCreator.addItemsToActor();
 
     if (game.settings.get(BRTCONFIG.NAMESPACE, BRTCONFIG.ALWAYS_SHOW_GENERATED_LOOT_AS_MESSAGE)) {
-      const lootChatCard = new LootChatCard(betterResults, currencyData)
-      await lootChatCard.createChatCard(tableEntity)
+      const lootChatCard = new LootChatCard(betterResults, currencyData);
+      await lootChatCard.createChatCard(tableEntity);
     }
 }
 
-  async addLootToSelectedToken (tableEntity) {
-    // VaderDojo: Only allow if tokens are selected
-    // TODO:  This check could be enhanced to only function if a UI toggle to use
-    // token logic is enabled
-    if (canvas.tokens.controlled.length === 0) { return ui.notifications.error('Please select a token first') }
+/**
+ * Roll a table an add the resulting loot to a given token.
+ * 
+ * @param {RollTable} tableEntity 
+ * @param {TokenDocument} token 
+ * @returns 
+ */
+  async addLootToSelectedToken (tableEntity, token = null) {
+    let tokenstack = [];
 
-    ui.notifications.info('Loot generation started.')
-    const brtBuilder = new BRTBuilder(tableEntity)
-
-    for (const token of canvas.tokens.controlled) {
-      const results = await brtBuilder.betterRoll()
-
-      const br = new BetterResults(results)
-      const betterResults = await br.buildResults(tableEntity)
-      const currencyData = br.getCurrencyData()
-      // console.log("++BETTER RESULTS ", betterResults);
-      // console.log("++ currencyData", currencyData);
-
-      const lootCreator = new LootCreator(betterResults, currencyData)
-
-      await lootCreator.addCurrenciesToToken(token)
-      await lootCreator.addItemsToToken(token)
+    if (null == token && (canvas.tokens.controlled.length === 0)) {
+        return ui.notifications.error('Please select a token first');
+    } else {
+        tokenstack = [token] || canvas.tokens.controlled;
     }
-    ui.notifications.info('Loot generation complete.')
+
+    ui.notifications.info('Loot generation started.');
+
+    const brtBuilder = new BRTBuilder(tableEntity);
+
+    for (const token of tokenstack) {
+      const results = await brtBuilder.betterRoll();
+      const br = new BetterResults(results);
+      const betterResults = await br.buildResults(tableEntity);
+      const currencyData = br.getCurrencyData();
+      const lootCreator = new LootCreator(betterResults, currencyData);
+
+      await lootCreator.addCurrenciesToToken(token);
+      await lootCreator.addItemsToToken(token);
+    }
+    
+    return ui.notifications.info('Loot generation complete.');
   }
 
   async generateChatLoot (tableEntity) {

--- a/scripts/core/brt-builder.js
+++ b/scripts/core/brt-builder.js
@@ -1,6 +1,7 @@
 import * as BRTHelper from './brt-helper.js'
 import * as Utils from '../core/utils.js'
 import { BRTCONFIG } from './config.js'
+import { addRollModeToChatData } from '../core/utils.js'
 
 export class BRTBuilder {
   constructor (tableEntity) {
@@ -13,18 +14,21 @@ export class BRTBuilder {
      * @returns {array} results
      */
   async betterRoll (rollsAmount = undefined) {
-    this.mainRoll = undefined
-    rollsAmount = rollsAmount || await BRTHelper.rollsAmount(this.table)
-    this.results = await this.rollManyOnTable(rollsAmount, this.table)
-    return this.results
+    this.mainRoll = undefined;
+    rollsAmount = rollsAmount || await BRTHelper.rollsAmount(this.table);
+    this.results = await this.rollManyOnTable(rollsAmount, this.table);
+    return this.results;
   }
 
   /**
      *
      * @param {array} results
      */
-  async createChatCard (results) {
-    await this.table.toMessage(results, { roll: this.mainRoll })
+  async createChatCard (results, rollMode = null) {
+
+    let msgData = { roll: this.mainRoll, messageData: {}};
+    if (rollMode) addRollModeToChatData(msgData.messageData, rollMode);
+    await this.table.toMessage(results, msgData);
   }
 
   /**

--- a/scripts/core/utils.js
+++ b/scripts/core/utils.js
@@ -1,7 +1,9 @@
 export const i18n = (key) => game.i18n && game.i18n.localize(key)
 
-export function addRollModeToChatData (chatData) {
-  switch (game.settings.get('core', 'rollMode')) {
+export function addRollModeToChatData (chatData, rollMode) {
+  rollMode = rollMode ?? game.settings.get('core', 'rollMode') ;
+
+  switch (rollMode) {
     case 'blindroll':
       chatData.blind = true
       // no break needed, if so please change this comment ?

--- a/scripts/loot/loot-chat-card.js
+++ b/scripts/loot/loot-chat-card.js
@@ -10,9 +10,10 @@ export class LootChatCard {
      * @param {object} betterResults
      * @param {object} currencyData
      */
-  constructor (betterResults, currencyData) {
+  constructor (betterResults, currencyData, rollMode) {
     this.betterResults = betterResults
     this.currencyData = currencyData
+    this.rollMode = rollMode
 
     this.itemsData = []
     this.numberOfDraws = 0
@@ -147,8 +148,8 @@ export class LootChatCard {
   }
 
   async createChatCard (table) {
-    const chatData = await this.prepareCharCart(table)
-    addRollModeToChatData(chatData)
-    ChatMessage.create(chatData)
+    const chatData = await this.prepareCharCart(table);
+    addRollModeToChatData(chatData, this.rollMode);    
+    ChatMessage.create(chatData);
   }
 }


### PR DESCRIPTION
Solves #72 

This adds support for an options argument for 
* generateLoot()
* generateChatLoot()
* betterTableRoll()

The options argument is used to check for a rollMode key. If found, the content (should be a string) will be used as the roll mode.
The default still is the rollMode set via the game settings/UI.

Be aware that this branch also has my changes from #141.