### PR TITLE
Fix filter method after rolltable generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <img alt="GitHub release (latest by date)" src="https://img.shields.io/github/v/release/ultrakorne/better-rolltables?style=flat-square"> <img alt="GitHub" src="https://img.shields.io/github/license/ultrakorne/better-rolltables?style=flat-square"> <img alt="GitHub Releases" src="https://img.shields.io/github/downloads/ultrakorne/better-rolltables/latest/total?style=flat-square">  
 
 # Better Rolltables #
-*better-rolltables* is Module for FoundryVTT to improve and add functionality to Rollable tables
-Implementing for example the Treasure Hoard" Tables from the Dungeon master manual becomes possible!
+*better-rolltables* is a module for [FoundryVTT](https://foundryvtt.com/) to improve and add functionality to rollable tables.
+Implementing for example the "Treasure Hoard" Tables from the Dungeons Masters Guide becomes possible!
 
 ### Intro video
 [![Overview video](https://img.youtube.com/vi/TRg4y0joOKA/0.jpg)](https://www.youtube.com/watch?v=TRg4y0joOKA)
@@ -13,19 +13,27 @@ Implementing for example the Treasure Hoard" Tables from the Dungeon master manu
 
 * Roll on multiple tables with roll formulas
 * Auto create a loot actor to store generated loot
+* Populate loot on a token
 * Auto roll random spells when a scroll is selected as loot
 * A table can specify multiple currencies (with roll formulas) to always be awarded
 
-### How to use it ###
+## How to use Better Rolltables ##
 
-Check the [**Wiki**](https://github.com/ultrakorne/better-rolltables/wiki) and start with [How to Loot Tables](https://github.com/ultrakorne/better-rolltables/wiki/Loot-Tables)
+Please check the [**Wiki**](https://github.com/ultrakorne/better-rolltables/wiki) and start with [How to use Loot Tables](https://github.com/ultrakorne/better-rolltables/wiki/Loot-Tables)
 
-To use the functionality in your macros, check out the [Macro guide](https://github.com/ultrakorne/better-rolltables/wiki/API-for-macros-and-modules#how-to-roll-tables-from-macros)
+To use the functionality in macros or other modules, check out the [API/Macro guide](https://github.com/ultrakorne/better-rolltables/wiki/API-for-macros-and-modules#how-to-roll-tables-from-macros)
 
-I suggest to use [loot sheet NPC module](https://github.com/jopeek/fvtt-loot-sheet-npc-5e). if you have that module installed, better rolltable will automatically use it.
+## Recommended module(s)
+I suggest to use [loot sheet NPC module](https://github.com/jopeek/fvtt-loot-sheet-npc-5e). 
+If the module is installed, Better Rolltable will automatically make use of it.
 
+Also [Loot Populater NPC 5E](https://github.com/DanielBoettner/fvtt-loot-populator-npc-5e) has
+Better Rolltables integration and allows to populate loot on tokens automatically based on certain rules and fallbacks.
 
 [FAQs](https://github.com/ultrakorne/better-rolltables/wiki/FAQ)
 
-### Contacts
-Ultrakorne#6240
+## Contacts
+If you have any suggestions or feedback, please [submit an issue on GitHub](https://github.com/ultrakorne/better-rolltables/issues) or try to contact via Discord.
+
+* Ultrakorne#6240
+* JackPrince#0494 (on [Github](https://github.com/DanielBoettner))

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "better-rolltables",
   "title": "Better Roll Tables",
   "description": "Adding functionality to roll tables, especially to roll treasure and magic items",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "authors": [
     {
       "name": "Ultrakorne#6240",
@@ -80,5 +80,5 @@
   ],
   "url": "https://github.com/ultrakorne/better-rolltables",
   "manifest": "https://raw.githubusercontent.com/ultrakorne/better-rolltables/master/module.json",
-  "download": "https://github.com/ultrakorne/better-rolltables/releases/download/v1.8.5/better-rolltables.zip"
+  "download": "https://github.com/ultrakorne/better-rolltables/releases/download/v1.8.6/better-rolltables.zip"
 }

--- a/scripts/better-tables.js
+++ b/scripts/better-tables.js
@@ -172,7 +172,7 @@ export class BetterTables {
       })
       .then(results => RollTable.create({
         name: tableName,
-        results: results.filter(x => x !== undefined) // remove empty results due to null weight
+        results: results.filter(x => x.weight !== 0) // remove empty results due to null weight
       }))
       .then(rolltable => {
         rolltable.normalize()

--- a/templates/welcome-screen.html
+++ b/templates/welcome-screen.html
@@ -27,9 +27,19 @@
 
 <h1>Patchnotes</h1>
 
+<h2 id="v186">v1.8.6</h2>
+<ul>
+    <li>Fixed a bug in <em>createTableFromCompendium()</em></li>
+</ul>
+
 <h2 id="v185">v1.8.5</h2>
 <ul>
     <li>various fixes</li>
+</ul>
+
+<h2 id="v184">v1.8.4</h2>
+<ul>
+    <li>Added a method that allows populating tokens (e.g. via macro)</li>
 </ul>
 
 <h2 id="v183">v1.8.3</h2>
@@ -86,7 +96,7 @@
 </ul>
 <h2 id="v1612">v1.6.12</h2>
 <ul>
-    <li>Another update from JackPrince # 0494 (<a href="https://github.com/DanielBoettner">github.com/DanielBoettner</a>) fixing generation of spellscrolls.</li>
+    <li>Another update from JackPrince#0494 (<a href="https://github.com/DanielBoettner">github.com/DanielBoettner</a>) fixing generation of spellscrolls.</li>
     <li>Add link and description of spell to the spell scrolls</li>
     <li>Updated the method to generate tables from a compendium</li>
     <li>Added an entry to the contextmenu of a compendium to start generation</li>


### PR DESCRIPTION
Don't know if this changed over time. 
But the original check didn't work.

The weight property should be checked for `0` instead of checking if the entity is undefined.
This error only occurred when using a `weightPredicate` and this predicate would return 0 (as per example from the Wiki) for an entity.

fixes #152 
closes #152 