### PR TITLE
[HotFix] Pathfinder 1 missing spell compendium

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "better-rolltables",
   "title": "Better Roll Tables",
   "description": "Adding functionality to roll tables, especially to roll treasure and magic items",
-  "version": "1.8.91",
+  "version": "1.8.92",
   "manifestPlusVersion": "1.2.0",
   "authors": [
     {

--- a/scripts/better-tables.js
+++ b/scripts/better-tables.js
@@ -187,16 +187,20 @@ export class BetterTables {
   }
 
   /**
-     * Update spell cache used for random spell scroll generation
-     * @returns {Promise<void>}
-     */
+   * Update spell cache used for random spell scroll generation
+   *
+   * @returns {Promise<void>}
+   */
   async updateSpellCache(pack) {
     if (game.user.isGM) {
-      const defaultPack = game.settings.get(MODULE.ns, BRTCONFIG.SPELL_COMPENDIUM_KEY);
-      if (!pack || pack === defaultPack) {
-        const spellCompendium = game.packs.get(defaultPack)
+      const defaultPack = game.settings.get(MODULE.ns, BRTCONFIG.SPELL_COMPENDIUM_KEY),
+            spellCompendium = game.packs.get(defaultPack);
+
+      if (!pack && spellCompendium || pack === defaultPack) {
         const spellCompendiumIndex = await spellCompendium.getIndex({ fields: ['data.level', 'img'] })
         this._spellCache = spellCompendiumIndex.filter(entry => entry.type === "spell").map(i => mergeObject(i, { collection: spellCompendium.collection }))
+      } else {
+        ui.notifications.error(MODULE.ns + `| Spell cache could not be initialized/updated.`);
       }
     }
   }

--- a/scripts/hooks/init.js
+++ b/scripts/hooks/init.js
@@ -53,7 +53,6 @@ class BetterRolltableHooks {
     if (game.user.isGM && VersionCheck.check(MODULE.ns)) {
       renderWelcomeScreen();
     }
-    await game.betterTables.updateSpellCache();
     
     /** Register Handlebar helpers **/
     /** checks if the first argument is equal to any of the subsequent arguments */
@@ -113,7 +112,9 @@ class BetterRolltableHooks {
       if (value == this.switch_value) {
         return options.fn(this)
       }
-    });    
+    });
+    
+    await game.betterTables.updateSpellCache();
   }
 
   static foundryInit() {

--- a/styles/tidyDefaults.less
+++ b/styles/tidyDefaults.less
@@ -1,4 +1,4 @@
-.system-dnd5e {
+.system-dnd5e, .system-pf1, .system-pf2e {
 	--modesto: "Modesto Condensed", "Palatino Linotype", serif;
 	--signika: "Signika", sans-serif;
 	--primary-font: rgba(0, 0, 0, 0.9);


### PR DESCRIPTION
When initialization of `updateSpellCache();` failed because no spell compendium is set,
the HandlebarHelpers didn't get registered.

This made BRT unusable for effected users.