### PR TITLE
Fixes for Foundry v9 and actors in loot tables

### DIFF
--- a/scripts/loot/loot-chat-card.js
+++ b/scripts/loot/loot-chat-card.js
@@ -63,7 +63,12 @@ export class LootChatCard {
 
   addToItemData (itemEntity, data) {
     const existingItem = this.itemsData.find(i => i.item.id === itemEntity.id)
-    const quantity = getProperty(data, BRTCONFIG.QUANTITY_PROPERTY_PATH) || 1
+    let quantity = getProperty(data, BRTCONFIG.QUANTITY_PROPERTY_PATH) || 1
+
+    // the quantity property may return bogus things on an actor. Override to 1
+    if(itemEntity instanceof Actor){
+       quantity = 1;
+    }
 
     if (existingItem) {
       existingItem.quantity = +existingItem.quantity + +quantity

--- a/scripts/story/story-builder.js
+++ b/scripts/story/story-builder.js
@@ -180,7 +180,8 @@ export class StoryBuilder {
       if (rollMatch) {
         const rollFormula = rollMatch[1]
         try {
-          valueResult = new Roll(rollFormula).roll().total || 0
+          let rollResult = await new Roll(rollFormula).evaluate({async: true});
+          valueResult = rollResult.total || 0;
         } catch (error) {
           valueResult = 0
         }

--- a/scripts/story/story-builder.js
+++ b/scripts/story/story-builder.js
@@ -36,7 +36,7 @@ export class StoryBuilder {
         const entity = await Utils.findInCompendiumByName(entry.data.collection, entry.data.text)
         if (!entity) {
           errorString = `entity ${entry.data.text} not found in compendium ${entry.data.collection}`
-        } else if (entity.entity === 'JournalEntry') {
+        } else if (entity.documentName === 'JournalEntry') {
           journalContent = entity.data.content
         } else {
           errorString = 'Only Journal entries are supported in the story generation as table results'
@@ -169,10 +169,17 @@ export class StoryBuilder {
       }
 
       const tableResult = draw.results[0]
-      if (tableResult.data.type !== 0) {
-        ui.notifications.warn(`only text result from table are supported at the moment, check table ${table.name}`)
+
+      if(tableResult.data.type == 1){
+        valueResult = `@Actor[${tableResult.data.resultId}]{${tableResult.data.text}}`;
       }
-      valueResult = tableResult.data.text
+      // Compendium
+      else if(tableResult.data.type == 2) {
+        valueResult = `@Compendium[${tableResult.data.collection}.${tableResult.data.resultId}]{${tableResult.data.text}}`;
+      }
+      else {
+        valueResult = tableResult.data.text;
+      }
     } else {
       const regexRoll = /\s*\[\[ *([^\]]*?) *\]\]/
       /** if no table match, lets check for a formula */


### PR DESCRIPTION
- Fixes rolling stories in v9
- Fixes loot tables with actors in them. It is retrieving a "quantity" field in the actor data. Of course, actors don't have quantity in the same way that items do. Actors represent a quantity of 1. Checks for actors and uses a quantity of 1. 

As a background, I'm using loot tables to roll for encounters. I noticed the count was doubled, and realized it was retrieving the data from an actor saying it had a quantity 2, as though it was an item. 